### PR TITLE
io_u: fix offset calculation in randtrimwrite

### DIFF
--- a/io_u.c
+++ b/io_u.c
@@ -431,7 +431,7 @@ static int get_next_block(struct thread_data *td, struct io_u *io_u,
 	if (td_randtrimwrite(td) && ddir == DDIR_WRITE) {
 		/* don't mark randommap for these writes */
 		io_u_set(td, io_u, IO_U_F_BUSY_OK);
-		offset = f->last_start[DDIR_TRIM];
+		offset = f->last_start[DDIR_TRIM] - f->file_offset;
 		*is_random = true;
 		ret = 0;
 	} else if (rw_seq) {


### PR DESCRIPTION
For randtrimwrite, we should issue trim + write pair and those offsets should be same.

This works good for cases without `offset=` option, but not for cases with `offset=` option.  In cases with `offset=` option, it's necessary to subtract `file_offset`, which is value of `offset=` option, when calculationg offset of write.

This is a bit confusing because `last_start` is an actual offset that has already been issued through trim.  However, `last_start` is the value to which `file_offset` is added.  Since we add back `file_offset` later on after calling `get_next_block` in `get_next_offset`, `last_start` should be adjusted.
